### PR TITLE
mraa: fixes configure error

### DIFF
--- a/recipes-devtools/mraa/mraa.inc
+++ b/recipes-devtools/mraa/mraa.inc
@@ -9,6 +9,8 @@ S = "${WORKDIR}/git"
 
 inherit distutils-base pkgconfig python-dir cmake
 
+DEPENDS += "nodejs-native"
+
 EXTRA_OECMAKE_append = "-DINSTALLGPIOTOOL=ON -DPYTHON_SITE_DIR:FILEPATH=${PYTHON_SITEPACKAGES_DIR} -DBASE_LIB_INSTALL_DIR=${base_libdir} -DCMAKE_SKIP_RPATH=ON"
 
 FILES_${PN}-doc += "${datadir}/mraa/examples/"


### PR DESCRIPTION
  |   Could NOT find Nodejs (missing: NODEJS_EXECUTABLE)

Definitely mraa breaks on my system, it wants nodejs-native. I fixed it the easiest possible way by adding 'DEPENDS' directive. Don't know mraa package well enough to judge if that's the best long-term solution.

Just for the record I tried to build 'core-image-xfce' from git://sandbox.sakoman.com/meta-gt-setup.git.
