### PR TITLE
xdk-daemon: Upstream Ostro recipe changes

### DIFF
--- a/recipes-devtools/node-inspector/node-inspector_0.12.8.bb
+++ b/recipes-devtools/node-inspector/node-inspector_0.12.8.bb
@@ -1,0 +1,17 @@
+SRC_URI = "npm://registry.npmjs.org;name=${PN};version=${PV}"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=480ea7e44791280d20fa258a33030275"
+
+DEPENDS = "bash"
+
+do_compile_prepend() {
+    export HOME="${WORKDIR}"
+
+    if [ "${TARGET_ARCH}" == "i586" ]; then
+        npm config set target_arch ia32
+        export TARGET_ARCH=ia32
+    fi
+}
+
+
+inherit npm

--- a/recipes-devtools/xdk-daemon/xdk-daemon_0.1.3.bb
+++ b/recipes-devtools/xdk-daemon/xdk-daemon_0.1.3.bb
@@ -3,21 +3,25 @@ LICENSE = "Proprietary"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=121fc3cd97e5c1db39627399a7d72288"
 
-DEPENDS = "nodejs-native mdns"
-RDEPENDS_${PN} = "libarchive-bin nodejs bash"
+DEPENDS = "nodejs-native avahi"
+RDEPENDS_${PN} = "nodejs node-inspector avahi openssh-sftp-server"
 
 PR = "r0"
 
 # needed to unset no_proxy for internal development
 export no_proxy = ""
 
-SRC_URI = "http://download.xdk.intel.com/iot/xdk-daemon-0.1.3.tar.bz2"
+SRC_URI = "http://download.xdk.intel.com/iot/xdk-daemon-${PV}.tar.bz2 \
+           "
 
 SRC_URI[md5sum] = "ffc1f11eb390e5846093c2b89fae052e"
 SRC_URI[sha256sum] = "23a8c1bb025a9b4dbc22e8e656a1bebfefcaba23831b14b52e8fe9966448571e"
 
 # we don't care about debug for the few binary node modules
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+# fix dns_sd linking
+SECURITY_CFLAGS_append = " -fPIC"
 
 do_compile () {
     # changing the home directory to the working directory, the .npmrc will be created in this directory
@@ -49,10 +53,12 @@ do_compile () {
         npm config set target_arch ia32
         export TARGET_ARCH=ia32
     fi
+
+    export CPLUS_INCLUDE_PATH=${STAGING_INCDIR}/avahi-compat-libdns_sd
+
     # npm is dumb, it needs to get given --arch but not in npm config
     npm install
-    cd current/ && npm install --arch=${TARGET_ARCH}
-    cd node-inspector-server && npm install --build-from-source --arch=${TARGET_ARCH}
+    cd current/ && npm install --verbose --arch=${TARGET_ARCH}
 
     sed -i '/TM/d' ${S}/xdk-daemon
 }
@@ -61,8 +67,13 @@ do_install () {
     install -d ${D}/opt/xdk-daemon/
     cp -a ${S}/* ${D}/opt/xdk-daemon/
 
+    # the above copies any .patch file as well. This can create broken
+    # symlinks, which can cause QA errors. Delete the patch directory to prevent
+    # these issues
+    rm -rf ${D}/opt/xdk-daemon/patches
+
     install -d ${D}${systemd_unitdir}/system/
-    install -m 0644 ${S}/xdk-daemon-mdns.service ${D}${systemd_unitdir}/system/xdk-daemon.service
+    install -m 0644 ${S}/xdk-daemon-avahi.service ${D}${systemd_unitdir}/system/xdk-daemon.service
 }
 
 inherit systemd


### PR DESCRIPTION
The xdk-daemon recipe currently in use by Ostro has been modified to
better suit Ostro Project needs. In order to avoid forks, the changes
are upstreamed.

The mdns dependency has been replaced by avahi, node inspector dependency
has been made explicit through another recipe and openssh-sftp-server
runtime dependency has been added.

Signed-off-by: Erkka Kääriä erkka.kaaria@intel.com
